### PR TITLE
[WIP] Trap errors resulting from malformed .arc files for n00bs like me who make obvious mistakes.

### DIFF
--- a/src/create/validate/_rest.js
+++ b/src/create/validate/_rest.js
@@ -20,13 +20,13 @@ module.exports = function _rest(type, arc, raw) {
         var path = route[1]
         var err = validPath(path)
         if (err) {
-            errors.push(Err({
-              message: `@${type} invalid route`,
-              linenumber: findLineNumber(route, raw),
-              raw,
-              arc,
-              detail: err.message + ' HTTP reference: https://arc.codes/guides/http',
-            }))
+          errors.push(Err({
+            message: `@${type} invalid route`,
+            linenumber: findLineNumber(route, raw),
+            raw,
+            arc,
+            detail: err.message + ' HTTP reference: https://arc.codes/guides/http',
+          }))
         }
       })
       // for each route in routes
@@ -44,7 +44,10 @@ module.exports = function _rest(type, arc, raw) {
 }
 
 function findLineNumber(tuple, raw) {
-  var search = tuple.join(' ')
+  var search = typeof tuple.join === 'function'
+    ? tuple.join(' ')
+    : tuple;
+
   var lines = raw.split('\n')
   for (var i = 0; i <= lines.length; i++) {
     if (lines[i] && lines[i].startsWith(search)) {

--- a/src/create/validate/index.js
+++ b/src/create/validate/index.js
@@ -27,7 +27,7 @@ module.exports = function validate(arc, raw, callback) {
   // - accept a parsed arc object and a raw arc file as a string
   // - return an array of error objects
   //
-  let validators = [
+  let validators = {
     app,
     css,
     domain,
@@ -42,16 +42,22 @@ module.exports = function validate(arc, raw, callback) {
     text,
     tables,
     xml,
-  ]
+  }
 
   // map function: accepts a validater; applies it to arc
-  let validate = validator=> validator(arc, raw)
+  let validate = ([key, validator]) => {
+    try {
+      return validator(arc, raw);
+    } catch (err) {
+      return err;
+    }
+  }
 
   // reduce function: just concats the error arrays into one array
-  let flatten = (a, b)=> a.concat(b)
+  let flatten = (a, b) => a.concat(b)
 
   // the final collection of errors
-  let errors = validators.map(validate).reduce(flatten)
+  let errors = Object.entries(validators).map(validate).reduce(flatten)
 
   // continue if everything is ok
   let ok = errors.length === 0


### PR DESCRIPTION
- [x] Forked the repository and created your branch from master
- [ ] Make sure the tests pass! `npm it && npm run lint` in the repository root
- [ ] If you've fixed a bug or added code **more** tests are appreciated
- [ ] If you haven't already please complete the CLA

Wanted to make sure I wasn't missing anything obvious @brianleroux before updating tests, executing CLA etc. If this fix is desired I will button up the tests, etc.

> And 👋how you been? Thanks for the hard work on arc 💚 

### `.arc` file with two mistakes
```
@app
my-app-longer-than-10-chars

@aws
region us-east-1
profile default

@json
/my/route/i/forgot/a/verb/to

```

### Output before
```
$ npx create                  
        ARC_APP_NAME my-app-longer-than-10-chars             
          AWS_REGION us-east-1                               
         AWS_PROFILE default                                 
                                                             
                Node 8.10.0                                  
                 npm 6.1.0                                   
                .arc 3.2.4                                   
                                                             
tuple.join is not a function
```

### Output after
```
$ npx create
                                                             
        ARC_APP_NAME my-app-longer-than-10-chars             
          AWS_REGION us-east-1                               
         AWS_PROFILE default                                 
                                                             
                Node 8.10.0                                  
                 npm 6.1.0                                   
                .arc 3.2.4                                   
                                                             
Error: .arc line 2 @app name > 10 characters
-----
   1. @app
▶  2. my-app-longer-than-10-chars
   3. 
   4. @aws
   5. region us-east-1
   6. profile default
   7. 
   8. @json
   9. /my/route/i/forgot/a/verb/to
  10. 
-----
@app name must be 10 characters or less.
```

... clearly I was making an obvious mistake with `@app`, but the error wasn't getting surfaced correctly due to the uncaptured `tuple.join is not a function`.

## Digging deeper 

I updated the `.arc` file, but even after fixing the incorrect `@app` name the `tuple.join is not a function` message persisted:

```
@app
validname

@aws
region us-east-1
profile default

@json
/my/route/i/forgot/a/verb/to
``` 

Further digging revealed this to be caused by another n00b mistake: _forgetting to add an HTTP verb to the `.arc` file for `@json`_ – this is where the offending `tuple.join is not a function` came from. I discovered the mismatch in expectations in `_rest.js` which is also updated. After handling both the `string` and `Array` case that the error was surfaced correctly:

```
$ npx create
                                                             
        ARC_APP_NAME validname                               
          AWS_REGION us-east-1                               
         AWS_PROFILE default                                 
                                                             
                Node 8.10.0                                  
                 npm 6.1.0                                   
                .arc 3.2.4                                   
                                                             
Error: .arc line 9 @json invalid route
-----
   1. @app
   2. validname
   3. 
   4. @aws
   5. region us-east-1
   6. profile default
   7. 
   8. @json
▶  9. /my/route/i/forgot/a/verb/to
  10. 
-----
Paths must start with /. HTTP reference: https://arc.codes/guides/http
```

#### Additional notes

- `npx create` fails demanding `@app` be "10 characters or less", but [`@app` docs](https://arc.codes/reference/app) state "Maximum of 20 characters" is valid.
- `npx create` fails demanding `@json` routes be "be less than 25 characters.", but [`@json` docs](https://arc.codes/reference/json) state "Maximum length of 100 characters" is valid.