### PR TITLE
Set correct request payload limit in sandbox

### DIFF
--- a/src/sandbox/http/index.js
+++ b/src/sandbox/http/index.js
@@ -12,9 +12,13 @@ var register = require('./register-route')
 var public = require('./public-middleware')
 
 // config arcana
+var limit = '6mb';
 var app = Router({mergeparams: true})
-app.use(body.json())
-app.use(body.urlencoded({extended: false}))
+app.use(body.json({limit}))
+app.use(body.urlencoded({
+  extended: false,
+  limit,
+}))
 app.use(public)
 
 // keep a reference up here for fns below


### PR DESCRIPTION
Hi.

I noticed that the request payload limit in the sandbox is impliitly set to the `body-parser`'s default of 100kb. Since the the [limit in Lambda is 6mb](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) I introduced that value to the sandbox.

Cheers.