### PR TITLE
✨ add --delete flag to static deployments

### DIFF
--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -1,14 +1,19 @@
 # npx deploy
 
-Deploy Lambda functions and static content to AWS.
+Deploy functions (from `src/`) and static assets (from `public/`) to AWS Lambda and S3 respectively.
 
 Deploy, unlike Create, is destructive: it will remorselessly overwrite cloud infrastructure under its purvue. 
 
 Deploy will also reset individual lambda function dependencies based on the dependency manifest currently present (i.e. `node_modules/` to the contents of the local `package-lock.json`).
 
+Deploy will _not_ delete remote static assets from S3 that are not present locally in `public/` _unless the `--delete` flag is specified_.
+
 ## Example Usage
 
 - `npx deploy [staging | --staging | -s]` deploy all Lambda functions and static assets to `staging` 
 - `npx deploy [staging | --staging | -s] src/html/get-index` deploy one Lambda function to `staging`
-- `npx deploy [production | --production | -p]` deploy all Lambda functions and static content to `production` 
+- `npx deploy [production | --production | -p]` deploy all Lambda functions and static assets to `production` 
 - `npx deploy [production | --production | -p] src/html/get-index` deploy one Lambda function to `production` 
+- `npx deploy static [staging | --staging | -s]` deploy only static assets to `staging`
+- `npx deploy static --delete [staging | --staging | -s]` deploy only static assets to `staging` and delete assets on S3 that are not present locally in `public/`
+- `npx deploy static [production | --production | -p]` deploy only static assets to `production`

--- a/src/deploy/helpers/flags.js
+++ b/src/deploy/helpers/flags.js
@@ -33,6 +33,9 @@ module.exports = function flags(start) {
                    args.includes('--public') ||
                    args.includes('/public')
 
+    // should we delete static assets not present locally under public/
+    let shouldDelete = args.includes('--delete')
+
     let isPath = args.some(arg=> arg.startsWith('/') ||
                  arg.startsWith('src'))
 
@@ -57,7 +60,7 @@ module.exports = function flags(start) {
       filters.push('tables')
 
     //callback(null, arc, raw, {isProd, env, isStatic, isPath, isLambda, start, all: args}, callback)
-    callback(null, arc, raw, {isProd, env, isStatic, isPath, isLambda, filters, start, all: args})
+    callback(null, arc, raw, {isProd, env, isStatic, isPath, isLambda, filters, shouldDelete, start, all: args})
   }
 }
 

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -18,6 +18,7 @@ function main(arc, raw, args, callback) {
   let tasks = []
   let env = args.env
   let start = args.start
+  let shouldDelete = args.shouldDelete
   let filters = args.filters
 
   if (args.isStatic) {
@@ -25,6 +26,7 @@ function main(arc, raw, args, callback) {
     tasks.push(function(callback) {
       deployPublic({
         env,
+        shouldDelete,
         arc,
       }, callback)
     })

--- a/src/deploy/public/_copy-to-s3.js
+++ b/src/deploy/public/_copy-to-s3.js
@@ -6,17 +6,16 @@ var chalk = require('chalk')
 var path = require('path')
 var fs = require('fs')
 
-module.exports = function factory(bucket, callback) {
+module.exports = function factory(bucket, shouldDelete, callback) {
 
   var s3 = new aws.S3({region: process.env.AWS_REGION})
 
-  console.log(`${chalk.green('✓ Success!')} ${chalk.green.dim('Deployed public')}`)
 
-  var s3Path = path.join(process.cwd(), 'public', '/**/*')
-  glob(s3Path, function _glob(err, files) {
+  var staticAssets = path.join(process.cwd(), 'public', '/**/*')
+  glob(staticAssets, function _glob(err, localFiles) {
     if (err) console.log(err)
-    var fns = files.map(file=> {
-      return function _maybeUpload(callback) {
+    var tasks = localFiles.map(file=> {
+      return function _maybeUploadFileToS3(callback) {
         let stats = fs.lstatSync(file)
         if (stats.isDirectory()) {
           callback() // noop
@@ -41,12 +40,10 @@ module.exports = function factory(bucket, callback) {
             }
             else {
               var before = file.replace(process.cwd(), '').substr(1)
-              var after = before.replace('public', '')
+              var after = before.replace(/^public/, '')
               var domain = `https://s3.${process.env.AWS_REGION}.amazonaws.com/`
               let last = `${domain}${bucket}${after}`
-              console.log(chalk.underline.cyan(last))
-              console.log(chalk.cyan.dim('-'.padEnd(last.length, '-')))
-              console.log(' ') //spacer.gif
+              console.log(`✓ ${chalk.underline.cyan(last)}`)
               callback()
             }
           })
@@ -56,6 +53,51 @@ module.exports = function factory(bucket, callback) {
         }
       }
     })
-    parallel(fns, callback)
+    if (shouldDelete) tasks.push(function _maybeDeleteFilesOnS3(callback) {
+      s3.listObjectsV2({Bucket:bucket}, function(err, filesOnS3) {
+        if (err) {
+          console.error('listing objects in s3 failed', err)
+          callback()
+        }
+        else {
+          // calculate diff between files_on_s3 and local_files
+          // TODO: filesOnS3.IsTruncated may be true if you have > 1000 files.
+          // might want to handle that (need to ask for next page, etc)...
+          var leftovers = filesOnS3.Contents.filter(function(s3File) {
+            return !localFiles.includes(
+              path.join(process.cwd(), 'public', s3File.Key.replace('/', path.sep)) // windows
+            )
+          }).map(function(s3File) {
+            return {Key: s3File.Key }
+          })
+          if (leftovers.length) {
+            var deleteParams = {
+              Bucket: bucket,
+              Delete: {
+                Objects: leftovers,
+                Quiet: false
+              }
+            }
+            s3.deleteObjects(deleteParams, function(err, data) {
+              if (err) {
+                console.error('deleting objects on s3 failed', err)
+              } else {
+                data.Deleted.forEach(function(deletedFile) {
+                  var file = path.join(process.cwd(), 'public', deletedFile.Key.replace('/', path.sep));
+                  console.log(`🔪 ${chalk.underline.yellow(file)}`)
+                })
+              }
+              callback()
+            })
+          } else {
+            callback()
+          }
+        }
+      })
+    })
+    parallel(tasks, function() {
+      console.log(`${chalk.green('✓ Success!')} ${chalk.green.dim('Deployed static assets from public' + path.sep)}`)
+      callback()
+    })
   })
 }

--- a/src/deploy/public/index.js
+++ b/src/deploy/public/index.js
@@ -16,6 +16,7 @@ module.exports = function deploy(params, callback) {
     callback()
   }
   else {
+    let shouldDelete = params.shouldDelete
     let pathToPublic = path.join(process.cwd(), 'public')
     // create public if it does not exist
     mkdir(pathToPublic)
@@ -29,7 +30,7 @@ module.exports = function deploy(params, callback) {
       else {
         let index = params.env === 'staging' ? 0 : 1
         let bucket = params.arc.static[index][1]
-        copyToS3(bucket, callback)
+        copyToS3(bucket, shouldDelete, callback)
       }
     })
   }

--- a/test/deploy/index-test.js
+++ b/test/deploy/index-test.js
@@ -28,7 +28,7 @@ var base = {
 test('if static should invoke deployPublic', t=> {
   resetSpies()
   t.plan(1)
-  deploy.main(base, {}, {isStatic: true}, () => {
+  deploy.main(base, {}, {isStatic: true, shouldDelete: false}, () => {
     t.ok(publicMock.called, 'deployPublic invoked')
     t.end()
   })

--- a/test/deploy/public/copy-to-s3.test.js
+++ b/test/deploy/public/copy-to-s3.test.js
@@ -11,9 +11,11 @@ var copy = proxyquire('../../../src/deploy/public/_copy-to-s3', {
 
 test('deploy/public/copy-to-s3 should put each globbed file under public as an object to s3', t=> {
   t.plan(4)
-  var s3Stub = sinon.stub().callsFake((params, callback) => callback())
+  var putStub = sinon.stub().callsFake((params, callback) => callback())
   sinon.stub(aws, 'S3').returns({
-    putObject: s3Stub
+    putObject: putStub,
+    listObjectsV2: sinon.stub().callsFake((params, callback) => callback(null, {Contents:[]})),
+    deleteObjects: sinon.stub().callsFake((params, callback) => callback(null, {Deleted:[]}))
   })
   globStub.resetBehavior()
   globStub.callsFake((filepath, callback) => callback(null, [path.join(process.cwd(), 'public', 'index.html')]))
@@ -22,13 +24,43 @@ test('deploy/public/copy-to-s3 should put each globbed file under public as an o
     isFile: () => true
   })
   sinon.stub(fs, 'readFileSync')
-  copy('bukit', () => {
+  copy('bukit', false/*shouldDelete*/, () => {
     fs.lstatSync.restore()
-    t.ok(s3Stub.called, 's3.putObject called')
-    var args = s3Stub.args[0][0]
+    t.ok(putStub.called, 's3.putObject called')
+    var args = putStub.args[0][0]
     t.equals(args.Bucket, 'bukit', 's3.putObject called with proper bucket name')
     t.equals(args.Key, 'index.html', 's3.putObject called with proper key name using file name')
     t.equals(args.ContentType, 'text/html', 's3.putObject called with proper content type')
+    fs.readFileSync.restore()
+    aws.S3.restore()
+    t.end()
+  })
+})
+
+test('deploy/public/copy-to-s3 should delete files present on the bucket but not in the ./public/ folder', t=> {
+  t.plan(3)
+  var deleteStub = sinon.stub().callsFake((params, callback) => callback(null, {Deleted:[{Key:'test.file'}]}))
+  var listStub = sinon.stub().callsFake((params, callback) => callback())
+  sinon.stub(aws, 'S3').returns({
+    putObject: sinon.stub().callsFake((params, callback) => callback()),
+    listObjectsV2: listStub,
+    deleteObjects: deleteStub
+  })
+  globStub.resetBehavior()
+  var localFiles = [path.join(process.cwd(), 'public', 'index.html')]
+  globStub.callsFake((filepath, callback) => callback(null, localFiles))
+  listStub.callsFake((params, callback) => callback(null, {Contents:[{Key:'index.html'}, {Key:'test.file'}]}))
+  sinon.stub(fs, 'lstatSync').returns({
+    isDirectory: () => false,
+    isFile: () => true
+  })
+  sinon.stub(fs, 'readFileSync')
+  copy('bukit', true/*shouldDelete*/, () => {
+    fs.lstatSync.restore()
+    t.ok(deleteStub.called, 's3.deleteObjects called')
+    var args = deleteStub.args[0][0]
+    t.equals(args.Bucket, 'bukit', 's3.deleteObjects called with proper bucket name')
+    t.equals(args.Delete.Objects[0].Key, 'test.file', 's3.deleteObjects called with proper key name using file name')
     fs.readFileSync.restore()
     aws.S3.restore()
     t.end()

--- a/test/deploy/public/index-test.js
+++ b/test/deploy/public/index-test.js
@@ -47,7 +47,7 @@ test('deploy/public should not invoke copy if public dir is empty', t=> {
 test('deploy/public should invoke copy with proper bucketname if public dir is not empty', t=> {
   t.plan(2)
   copyStub.resetHistory()
-  copyStub.callsFake((bucket, callback) => callback())
+  copyStub.callsFake((bucket, shouldDelete, callback) => callback())
   var arc = Object.assign(base, {static:[['staging', 'stagingbucket'], ['production', 'prodbucket']]})
   let readStub = sinon.stub(fs, 'readdir').callsFake((path, callback) => callback(null, ['index.html']))
   deployPublic({ arc, env: '' }, () => {


### PR DESCRIPTION
- 📝 updated deploy documentation with --delete (and static-only deploys)
- 💄 updated how static asset deploys log to terminal
- calculates diff between local fileset and remote fileset using listObjectsV2 and deleteObjects aws-sdk APIS
- ✅ updated public deploy tests to reflect small change in parameter configuration in public module, added test for deletion

This PR relates to #187. I am warming up to land delta-deploys in here next to be able to close that issue. Watch out for that PR upcoming.

Thank you for helping out! ✨

Before submitting a pull request, please make sure the you checked the following:

- [x] Forked the repository and created your branch from master
- [x] Make sure the tests pass! `npm it && npm run lint` in the repository root
- [x] If you've fixed a bug or added code **more** tests are appreciated
- [x] If you're adding a new command, removing an old command, or changing how a command works, please update the relevant documentation for the command (under the `doc/` folder)
- [x] If you haven't already please complete the CLA

Learn more about contributing: https://arc.codes/intro/community

