### PR TITLE
Add @queue support to sandbox

### DIFF
--- a/src/sandbox/events/_subprocess.js
+++ b/src/sandbox/events/_subprocess.js
@@ -6,17 +6,28 @@ let path = require('path')
  */
 process.on('message', function msg(message) {
   // require in the lambda
-  let lambda = require(path.join(process.cwd(), 'src', 'events', message.name))
+  let lambda = require(path.join(process.cwd(), 'src', message.arcType + 's', message.name))
   // mock out an SNS payload...
-  let event = {Records:[{Sns:{Message:JSON.stringify(message.payload)}}]} // this is fine
+  let event = mockEvent(message)
   // mock context
   let context = {}
   // run the lambda locally
   lambda.handler(event, context, function done(err) {
-    let text = err? `@event ${message.name} failed with ${err.message}` : `@event ${message.name} complete`
+    let text = err? `@${message.arcType} ${message.name} failed with ${err.stack}` : `@${message.arcType} ${message.name} complete`
     // send a message to the parent node process
     process.send({text})
     // cleanup
     process.exit()
   })
 })
+
+function mockEvent(message) {
+  switch (message.arcType) {
+  case "event":
+    return {Records:[{Sns:{Message:JSON.stringify(message.payload)}}]}; // this is fine
+  case "queue":
+    return { Records: [{ body: JSON.stringify(message.payload) }] }; // also fine
+  default:
+    throw new Error('Unrecognized event type ' + message.arcType)
+  }
+}

--- a/src/sandbox/events/index.js
+++ b/src/sandbox/events/index.js
@@ -14,8 +14,8 @@ function start(callback) {
   let {arc} = readArc()
   let close = x=> !x
 
-  // if .arc has events and we're not clobbering with ARC_LOCAL flag
-  if (arc.events && !process.env.hasOwnProperty('ARC_LOCAL')) {
+  // if .arc has events or queues and we're not clobbering with ARC_LOCAL flag
+  if ((arc.events || arc.queues) && !process.env.hasOwnProperty('ARC_LOCAL')) {
     // start a little web server
     let server = http.createServer(function listener(req, res) {
       let body = ''


### PR DESCRIPTION
Following up on https://github.com/arc-repos/architect/issues/131#issuecomment-444937313, here's some changes to the sandbox event bus that makes it handle `@queue` lambdas as well. There's a related change to `@architect/functions` that is needed for queues to work, but events should continue to work fine with this change.

### Checklist

- [x] Forked the repository and created your branch from master
- [x] Make sure the tests pass! `npm it` in the repository root
- [ ] If you've fixed a bug or added code **more** tests are appreciated
- [x] If you haven't already please complete the CLA

Learn more about contributing: https://arc.codes/intro/community
