### PR TITLE
Fix: propagate npm ci errors during deploy

### DIFF
--- a/src/create/aws/_install-workflows-and-data.js
+++ b/src/create/aws/_install-workflows-and-data.js
@@ -1,18 +1,14 @@
 let parse = require('@architect/parser')
 let exists = require('path-exists').sync
-let spawn = require('child_process').spawn
 let path = require('path')
 let mkdir = require('mkdirp').sync
 let fs = require('fs')
 let cp = fs.copyFileSync
+let npm = require('../../util/npm')
 
 module.exports = function _installFunctionsAndData(localPath, callback) {
-  let cmd = process.platform.startsWith('win')? 'npm.cmd' : 'npm'
-  let args =  ['i', '@architect/functions', '@architect/data', '--ignore-scripts']
-  let opts = {cwd:localPath, shell:true}
-  let npm = spawn(cmd, args, opts)
-  npm.on('close', function win() {
-    var pathToLocalArcCopy = path.join(localPath, 'node_modules', '@architect', 'shared')
+  npm(localPath, ['i', '@architect/functions', '@architect/data', '--ignore-scripts'], err => {
+    let pathToLocalArcCopy = path.join(localPath, 'node_modules', '@architect', 'shared')
     mkdir(pathToLocalArcCopy)
     let arcDefaultPath = path.join(process.cwd(), '.arc')
     let arcFinalPath = path.join(pathToLocalArcCopy, '.arc')
@@ -31,7 +27,6 @@ module.exports = function _installFunctionsAndData(localPath, callback) {
       let arc = parse.json.stringify(raw)
       fs.writeFileSync(path.join(pathToLocalArcCopy, '.arc'), arc)
     }
-    callback()
+    callback(err) // propagate npm error to caller
   })
-  npm.on('error', callback)
 }

--- a/src/create/aws/create-slack-endpoints/_create-code.js
+++ b/src/create/aws/create-slack-endpoints/_create-code.js
@@ -6,7 +6,7 @@ var fs = require('fs')
 var cp = fs.copyFileSync
 var parallel = require('run-parallel')
 var assert = require('@smallwins/validate/assert')
-let spawn = require('child_process').spawn
+let npm = require('../../../util/npm')
 
 
 /**
@@ -66,15 +66,10 @@ module.exports = function createSlackLambdaCode(params, callback) {
 }
 
 function install(localPath, callback) {
-  let cmd = process.platform.startsWith('win')? 'npm.cmd' : 'npm'
-  let args =  ['i', 'slack', '@architect/data', '--ignore-scripts']
-  let opts = {cwd:localPath, shell:true}
-  let npm = spawn(cmd, args, opts)
-  npm.on('close', function win() {
+  npm(localPath, ['i', 'slack', '@architect/data', '--ignore-scripts'], err => {
     var pathToLocalArcCopy = path.join(localPath, 'node_modules', '@architect', 'shared')
     mkdir(pathToLocalArcCopy)
     cp(path.join(process.cwd(), '.arc'), path.join(pathToLocalArcCopy, '.arc'))
-    callback()
+    callback(err) // propagate npm error to caller
   })
-  npm.on('error', callback)
 }

--- a/src/deploy/lambda-one/02-install-modules.js
+++ b/src/deploy/lambda-one/02-install-modules.js
@@ -1,30 +1,12 @@
-let path = require('path')
-let {spawn} = require('child_process')
+let npm = require('../../util/npm')
 
 /**
  * installs modules using package-lock.json
  */
 module.exports = function _modules(params, callback) {
-
   let {pathToCode, tick} = params
   if (tick)
     tick('Installing modules...')
 
-  let lock = path.join(process.cwd(), pathToCode)
-  let env = process.env
-  let opts = {cwd:lock, shell:true, env}
-  let windows = process.platform.startsWith('win')
-  let subprocess = spawn(windows? 'npm.cmd' : 'npm', ['ci', '--ignore-scripts'], opts)
-
-  let stderr = []
-  subprocess.stderr.on('data', chunk => stderr.push(chunk))
-  subprocess.on('exit', function close(code) {
-    callback(code !== 0 ? new Error(`npm ci in ${lock} exited with code ${code}\n${Buffer.concat(stderr).toString()}`) : null)
-  })
-
-  subprocess.on('error', function error(err) {
-    if (err)
-      console.log('npm ci failed', err)
-    callback()
-  })
+  npm(pathToCode, ['ci', '--ignore-scripts'], callback)
 }

--- a/src/deploy/lambda-one/02-install-modules.js
+++ b/src/deploy/lambda-one/02-install-modules.js
@@ -16,8 +16,10 @@ module.exports = function _modules(params, callback) {
   let windows = process.platform.startsWith('win')
   let subprocess = spawn(windows? 'npm.cmd' : 'npm', ['ci', '--ignore-scripts'], opts)
 
-  subprocess.on('close', function close() {
-    callback()
+  let stderr = []
+  subprocess.stderr.on('data', chunk => stderr.push(chunk))
+  subprocess.on('exit', function close(code) {
+    callback(code !== 0 ? new Error(`npm ci in ${lock} exited with code ${code}\n${Buffer.concat(stderr).toString()}`) : null)
   })
 
   subprocess.on('error', function error(err) {

--- a/src/hydrate/index.js
+++ b/src/hydrate/index.js
@@ -96,10 +96,11 @@ function _install(pathToCode, callback) {
   let subprocess = spawn(cmd, args, options)
   // one tick for opening the process
   progress.tick()
-  subprocess.on('close', function win() {
-    // and one tick per close
+  let stderr = []
+  subprocess.stderr.on('data', chunk => stderr.push(chunk))
+  subprocess.on('exit', function close(code) {
     progress.tick()
-    callback()
+    callback(code !== 0 ? new Error(`npm ci in ${lock} exited with code ${code}\n${Buffer.concat(stderr).toString()}`) : null)
   })
   subprocess.on('error', function fail(err) {
     callback(err)

--- a/src/util/npm.js
+++ b/src/util/npm.js
@@ -1,0 +1,23 @@
+let path = require('path')
+let spawn = require('child_process').spawn
+
+// helper function for running npm in a particular directory
+function npm(pathToCode, args, callback) {
+  let cwd = pathToCode.startsWith('/') ? pathToCode : path.join(process.cwd(), pathToCode)
+  // normalize pathToCode for error messages
+  pathToCode = pathToCode.replace(process.cwd() + '/', '')
+  let win = process.platform.startsWith('win')
+  let cmd = win? 'npm.cmd' : 'npm'
+  let options = {cwd, shell:true}
+  let subprocess = spawn(cmd, args, options)
+  let stderr = []
+  subprocess.stderr.on('data', chunk => stderr.push(chunk))
+  subprocess.on('exit', function close(code) {
+    callback(code !== 0 ? new Error(`npm ${args.join(' ')} in ${pathToCode} exited with code ${code}\n${Buffer.concat(stderr).toString()}`) : null)
+  })
+  subprocess.on('error', function fail(err) {
+    callback(err)
+  })
+}
+
+module.exports = npm


### PR DESCRIPTION
The `deploy` command currently shells out to `npm ci --ignore-scripts` in each lambdas directory, but it doesn't check whether npm succeeded. This leads to a really nasty behaviour where lambdas can be deployed with missing dependencies.

I can reliably reproduce this locally by running `npx deploy` in a project with about a dozen lambdas. Before this change, some of my lambdas would be broken after every deploy. After this change I see errors like this:

```
Error: npm ci in <snip: /path/to/my/lambda> exited with code 1
npm WARN prepare removing existing node_modules/ before installation
fs.js:667
  return binding.open(pathModule.toNamespacedPath(path),
                 ^

Error: ENFILE: file table overflow, open '/usr/local/lib/node_modules/npm/node_modules/minipass/index.js'
   <snip: stack trace in npm>
```

This is a bit ugly, but a hell of a lot better than deploying a broken lambda 😄 

### checklist

- [x] Forked the repository and created your branch from master
- [x] Make sure the tests pass! `npm it` in the repository root
- [ ] If you've fixed a bug or added code **more** tests are appreciated

I don't know how to start testing this... I guess we could set up a lambda with an invalid package.json or something else that would guarantee npm to fail?
