### PR TITLE
default DDB tables to use on-demand/pay-per-request

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@ Also see the [Architect functions changelog](https://github.com/arc-repos/arc-fu
 
 - [dev] Added test run watcher script.
 
+### Changed
+
+- DynamoDB tables now use on-demand/pay-per-request billing mode, mitigating the need for capacity planning
+
 ## [4.4.12] - 2018-12-23
 
 

--- a/src/create/aws/create-table-index/_get-global-secondary-indexes.js
+++ b/src/create/aws/create-table-index/_get-global-secondary-indexes.js
@@ -7,10 +7,6 @@ module.exports = function _getGsi(name, attr) {
       KeySchema: getKeySchema(attr),
       Projection: {
         ProjectionType: 'ALL'
-      },
-      ProvisionedThroughput: {
-        ReadCapacityUnits: 1,
-        WriteCapacityUnits: 1
       }
     }
   }]

--- a/src/create/aws/create-tables/_create-table.js
+++ b/src/create/aws/create-tables/_create-table.js
@@ -34,10 +34,7 @@ module.exports = function _createTable(name, attr, callback) {
               TableName,
               AttributeDefinitions: getAttributeDefinitions(clean(attr)),
               KeySchema: getKeySchema(attr, keys),
-              ProvisionedThroughput: {
-                ReadCapacityUnits: 1,
-                WriteCapacityUnits: 1
-              }
+              BillingMode: 'PAY_PER_REQUEST'
             }, callback)
           },
           function _maybeWaitForCreateComplete(result, callback) {


### PR DESCRIPTION
closes #253 