### PR TITLE
adds create-http-fallback

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,24 @@ Also see:
 - [Architect Data changelog](https://github.com/arc-repos/arc-data/blob/master/changelog.md)
 ---
 
+## [5.5.0] 2019-02-03
+
+SPA support: mount S3 on the / of API Gateway
+
+### Added
+
+- `ANY /{proxy+}` will now route any 'not found' to the HTTP Lambda `src/http/get-index`
+- NOTE: proxy+ routes have a slightly different request payload that includes `request.requestContext` not available to regular HTTP Lambdas (so you can use this to test a 404 condition)
+- `ANY /_static/{proxy+}` will proxy to S3 buckets defined by `@static` (this is if you want to skip proxying through lambda)
+- Companion library `@architect/functions` also gained `arc.proxy.public` superpower for proxying all requests NOT defined by `.arc` to the `@static` S3 buckets
+
+[For more about single page apps with Architect see there docs here.](https://arc.codes/guides/spa)
+
+### Changed
+
+- If `@http` is defined then `get /` must also be defined
+- `npx sandbox` now mounts `/public` on `http://localhost:3333/_static` to match the deployed API Gateway S3 proxy
+
 ## [5.0.6] 2019-01-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -417,9 +417,10 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.393.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.393.0.tgz",
-      "integrity": "sha512-PSsIoLusMl8yygd8CohBFVnzSiDZy6EPKnGs5MWT7U/kjwablAXN23voyi6K8vOaEC8J9lgbWW9P62wcijuhdQ==",
+      "version": "2.395.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.395.0.tgz",
+      "integrity": "sha512-ldTTjctniZT4E2lq2z3D8Y2u+vpkp+laoEnDkXgjKXTKbiJ0QEtfWsUdx/IQ7awCt8stoxyqZK47DJOxIbRNoA==",
+      "dev": true,
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -507,7 +508,8 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
     },
     "big.js": {
       "version": "5.2.2",
@@ -577,6 +579,7 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -1313,7 +1316,8 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -1576,27 +1580,27 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
@@ -1607,13 +1611,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -1623,39 +1627,39 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": false,
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -1665,28 +1669,28 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -1696,14 +1700,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -1720,7 +1724,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
@@ -1735,14 +1739,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "resolved": false,
           "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
@@ -1752,7 +1756,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -1762,7 +1766,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -1773,20 +1777,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -1795,14 +1799,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -1811,13 +1815,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
@@ -1827,7 +1831,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
@@ -1837,7 +1841,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -1846,14 +1850,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
@@ -1865,7 +1869,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "resolved": false,
           "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
@@ -1884,7 +1888,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -1895,14 +1899,14 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "resolved": false,
           "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
@@ -1913,7 +1917,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -1926,20 +1930,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -1948,21 +1952,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -1973,21 +1977,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "resolved": false,
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
@@ -2000,7 +2004,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -2009,7 +2013,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -2025,7 +2029,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "resolved": false,
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
@@ -2035,48 +2039,48 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -2087,7 +2091,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -2097,7 +2101,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2106,14 +2110,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "resolved": false,
           "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
@@ -2129,14 +2133,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
@@ -2146,13 +2150,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
@@ -2369,7 +2373,8 @@
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -2763,7 +2768,8 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -3339,7 +3345,7 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
@@ -3350,19 +3356,19 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "append-transform": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
           "dev": true,
           "requires": {
@@ -3371,31 +3377,31 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -3405,13 +3411,13 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "caching-transform": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tTfemGmFWe7KZ3KN6VsSgQZbd9Bgo7A40wlp4PTsJJvFu4YAnEC5YnfdiKq6Vh2i9XJLnA9n8OXD46orVpnPMw==",
           "dev": true,
           "requires": {
@@ -3423,14 +3429,14 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "optional": true,
@@ -3441,7 +3447,7 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
@@ -3453,7 +3459,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
@@ -3462,25 +3468,25 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.6.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
           "dev": true,
           "requires": {
@@ -3489,7 +3495,7 @@
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
@@ -3499,7 +3505,7 @@
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
@@ -3508,19 +3514,19 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
           "dev": true,
           "requires": {
@@ -3529,7 +3535,7 @@
         },
         "error-ex": {
           "version": "1.3.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
           "dev": true,
           "requires": {
@@ -3538,13 +3544,13 @@
         },
         "es6-error": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
@@ -3559,7 +3565,7 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "dev": true,
               "requires": {
@@ -3572,7 +3578,7 @@
         },
         "find-cache-dir": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
           "dev": true,
           "requires": {
@@ -3583,7 +3589,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -3592,7 +3598,7 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
@@ -3602,25 +3608,25 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
@@ -3634,13 +3640,13 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
@@ -3652,7 +3658,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
@@ -3663,25 +3669,25 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.7.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
@@ -3691,31 +3697,31 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
@@ -3724,31 +3730,31 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-ufiZoiJ8CxY577JJWEeFuxXZoMqiKpq/RqZtOAYuQLvlkbJWscq9n3gc4xrCGH9n4pW0qnTxOz1oyMmVtk8E1w==",
           "dev": true,
           "requires": {
@@ -3772,7 +3778,7 @@
         },
         "istanbul-lib-report": {
           "version": "2.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-rJ8uR3peeIrwAxoDEbK4dJ7cqqtxBisZKCuwkMtMv0xYzaAnsAi3AHrHPAAtNXzG/bcCgZZ3OJVqm1DTi9ap2Q==",
           "dev": true,
           "requires": {
@@ -3783,7 +3789,7 @@
         },
         "istanbul-lib-source-maps": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-30l40ySg+gvBLcxTrLzR4Z2XTRj3HgRCA/p2rnbs/3OiTaoj054gAbuP5DcLOtwqmy4XW8qXBHzrmP2/bQ9i3A==",
           "dev": true,
           "requires": {
@@ -3796,7 +3802,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
@@ -3804,7 +3810,7 @@
         },
         "istanbul-reports": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-CT0QgMBJqs6NJLF678ZHcquUAZIoBIUNzdJrRJfpkI9OnzG6MkUfHxbJC3ln981dMswC7/B1mfX3LNkhgJxsuw==",
           "dev": true,
           "requires": {
@@ -3813,13 +3819,13 @@
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -3828,14 +3834,14 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
@@ -3844,7 +3850,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
@@ -3856,7 +3862,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -3866,19 +3872,19 @@
         },
         "lodash.flattendeep": {
           "version": "4.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
@@ -3888,7 +3894,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
@@ -3897,7 +3903,7 @@
         },
         "md5-hex": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
           "dev": true,
           "requires": {
@@ -3906,13 +3912,13 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
@@ -3921,7 +3927,7 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
@@ -3930,7 +3936,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
@@ -3938,13 +3944,13 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -3953,13 +3959,13 @@
         },
         "minimist": {
           "version": "0.0.10",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -3968,7 +3974,7 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
@@ -3976,13 +3982,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
@@ -3994,7 +4000,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
@@ -4003,13 +4009,13 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -4018,7 +4024,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
@@ -4028,13 +4034,13 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
@@ -4045,13 +4051,13 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
           "dev": true,
           "requires": {
@@ -4060,7 +4066,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -4069,13 +4075,13 @@
         },
         "p-try": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
           "dev": true
         },
         "package-hash": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
           "dev": true,
           "requires": {
@@ -4087,7 +4093,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -4097,25 +4103,25 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-type": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
@@ -4124,13 +4130,13 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
@@ -4139,13 +4145,13 @@
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
@@ -4156,7 +4162,7 @@
         },
         "read-pkg-up": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
@@ -4166,7 +4172,7 @@
         },
         "release-zalgo": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
           "dev": true,
           "requires": {
@@ -4175,31 +4181,31 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "optional": true,
@@ -4209,7 +4215,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
@@ -4218,25 +4224,25 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
@@ -4245,26 +4251,26 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
@@ -4278,7 +4284,7 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
@@ -4288,13 +4294,13 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
@@ -4304,13 +4310,13 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
@@ -4320,7 +4326,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -4329,19 +4335,19 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
@@ -4350,7 +4356,7 @@
         },
         "test-exclude": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==",
           "dev": true,
           "requires": {
@@ -4362,7 +4368,7 @@
         },
         "uglify-js": {
           "version": "2.8.29",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
@@ -4374,7 +4380,7 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true,
@@ -4389,20 +4395,20 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "uuid": {
           "version": "3.3.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "dev": true,
           "requires": {
@@ -4412,7 +4418,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
@@ -4421,26 +4427,26 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
@@ -4450,13 +4456,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
@@ -4465,7 +4471,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
@@ -4476,7 +4482,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
@@ -4487,13 +4493,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.3.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "dev": true,
           "requires": {
@@ -4504,19 +4510,19 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -4536,7 +4542,7 @@
           "dependencies": {
             "cliui": {
               "version": "4.1.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "dev": true,
               "requires": {
@@ -4547,7 +4553,7 @@
             },
             "find-up": {
               "version": "2.1.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
               "dev": true,
               "requires": {
@@ -4556,7 +4562,7 @@
             },
             "locate-path": {
               "version": "2.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
               "dev": true,
               "requires": {
@@ -4566,7 +4572,7 @@
             },
             "p-limit": {
               "version": "1.3.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
               "dev": true,
               "requires": {
@@ -4575,7 +4581,7 @@
             },
             "p-locate": {
               "version": "2.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
               "dev": true,
               "requires": {
@@ -4584,7 +4590,7 @@
             },
             "p-try": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
               "dev": true
             }
@@ -4592,7 +4598,7 @@
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
@@ -4601,7 +4607,7 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
@@ -4982,7 +4988,8 @@
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -4992,7 +4999,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "randomatic": {
       "version": "3.1.1",
@@ -5557,7 +5565,8 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
     },
     "semver": {
       "version": "5.6.0",
@@ -6665,6 +6674,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -6689,7 +6699,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -6795,6 +6806,7 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
@@ -6802,8 +6814,9 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
   "license": "Apache-2.0",
   "homepage": "https://arc.codes",
   "dependencies": {
+    "aws-sdk": "^2.395.0",
     "@architect/data": "^2.0.12",
     "@architect/parser": "^1.1.6",
     "@smallwins/validate": "^4.3.0",
-    "aws-sdk": "^2.392.0",
     "body-parser": "^1.18.3",
     "chalk": "^2.4.2",
     "clear": "^0.1.0",

--- a/src/create/_planner.js
+++ b/src/create/_planner.js
@@ -110,6 +110,7 @@ module.exports = function planner(arc) {
     arc.http.forEach(route=> {
       plans.push({action:'create-http-route', route, app})
     })
+    plans.push({action:'create-http-fallback', app, arc})
     plans.push({action:'create-http-router-deployments', app})
   }
 

--- a/src/create/_planner.js
+++ b/src/create/_planner.js
@@ -65,13 +65,6 @@ module.exports = function planner(arc) {
   }
 
   //
-  // s3 buckets
-  //
-  if (arc.static && !process.env.ARC_LOCAL) {
-    plans.push({action:'create-http-static-deployments', static:arc.static})
-  }
-
-  //
   // dynamo tables
   //
   if (arc.tables) {
@@ -102,6 +95,14 @@ module.exports = function planner(arc) {
 
 
   //
+  // s3 buckets
+  //
+  if (arc.static && !process.env.ARC_LOCAL) {
+    plans.push({action:'create-http-static-deployments', static:arc.static})
+  }
+
+
+  //
   // api gateway http
   //
   let hasAPI = arc.hasOwnProperty('http')
@@ -111,6 +112,9 @@ module.exports = function planner(arc) {
       plans.push({action:'create-http-route', route, app})
     })
     plans.push({action:'create-http-fallback', app, arc})
+    if (arc.static) {
+      plans.push({action:'create-http-static-proxy', app, arc})
+    }
     plans.push({action:'create-http-router-deployments', app})
   }
 

--- a/src/create/aws/create-http-fallback/iam.js
+++ b/src/create/aws/create-http-fallback/iam.js
@@ -1,0 +1,34 @@
+let aws = require('aws-sdk')
+let waterfall = require('run-waterfall')
+
+/**
+ * adds the invoke permission
+ */
+module.exports = function iam({restApiId, arn}, callback) {
+  let region = process.env.AWS_REGION
+  let sts = new aws.STS({region})
+  let lambda = new aws.Lambda({region})
+  waterfall([
+    function getAccount(callback) {
+      sts.getCallerIdentity({}, function _getIdx(err, result) {
+        if (err) callback(err)
+        else {
+          callback(null, result.Account)
+        }
+      })
+    },
+    function addPermission(account, callback) {
+      lambda.addPermission({
+        FunctionName: arn,
+        Action: 'lambda:InvokeFunction',
+        Principal: "apigateway.amazonaws.com",
+        StatementId: "arc-idx-" + Date.now(),
+        SourceArn: `arn:aws:execute-api:${region}:${account}:${restApiId}/*/*`,
+      }, callback)
+    },
+  ],
+  function done(err) {
+    if (err) callback(err)
+    else callback()
+  })
+}

--- a/src/create/aws/create-http-fallback/index.js
+++ b/src/create/aws/create-http-fallback/index.js
@@ -1,0 +1,21 @@
+let assert = require('@smallwins/validate/assert')
+let series = require('run-series')
+let proxy = require('./proxy')
+
+/**
+ * catch any 404 and point it at get-index
+ */
+module.exports = function fallback(params, callback) {
+  assert(params, {
+    app: String,//app name
+    arc: Object,
+  })
+  series([
+    proxy.bind({}, 'staging', params.app),
+    proxy.bind({}, 'production', params.app),
+  ],
+  function done(err) {
+    if (err) callback(err)
+    else callback()
+  })
+}

--- a/src/create/aws/create-http-fallback/proxy.js
+++ b/src/create/aws/create-http-fallback/proxy.js
@@ -1,0 +1,29 @@
+let waterfall = require('run-waterfall')
+let verify = require('./verify')
+let read = require('./read')
+let write = require('./write')
+let iam = require('./iam')
+
+/**
+ * creates `ANY /{proxy+}` for one api pointing to get-index
+ */
+module.exports = function proxy(env, app, callback) {
+  waterfall([
+    read.bind({}, {app, env}),
+    verify,
+    write.bind({}, {app, env}),
+    iam,
+  ],
+  function done(err) {
+    if (err && err === 'cancel') {
+      console.log('cancelling')
+      callback()
+    }
+    else if (err) {
+      callback(err)
+    }
+    else {
+      callback()
+    }
+  })
+}

--- a/src/create/aws/create-http-fallback/read.js
+++ b/src/create/aws/create-http-fallback/read.js
@@ -1,0 +1,38 @@
+let aws = require('aws-sdk')
+let parallel = require('run-parallel')
+
+module.exports = function reads({app, env}, callback) {
+
+  let region = process.env.AWS_REGION
+  let api = new aws.APIGateway({region})
+  let lambda = new aws.Lambda({region})
+
+  parallel({
+    // read the restApiId
+    restApiId(callback) {
+      api.getRestApis({
+        limit: 500
+      },
+      function getRestApis(err, apis) {
+        if (err) callback(err)
+        else {
+          let byName = i=> i.name === `${app}-${env}`
+          let api = apis.items.find(byName)
+          callback(null, api.id)
+        }
+      })
+    },
+    // read the lambda arn
+    arn(callback) {
+      lambda.getFunction({
+        FunctionName: `${app}-${env}-get-index`
+      },
+      function getFunction(err, result) {
+        if (err) callback(err)
+        else {
+          callback(null, result.Configuration.FunctionArn)
+        }
+      })
+    }
+  }, callback)
+}

--- a/src/create/aws/create-http-fallback/verify.js
+++ b/src/create/aws/create-http-fallback/verify.js
@@ -1,0 +1,16 @@
+let aws = require('aws-sdk')
+
+module.exports = function verify({arn, restApiId}, callback) {
+  let region = process.env.AWS_REGION
+  let api = new aws.APIGateway({region})
+  api.getResources({restApiId}, function done(err, result) {
+    if (err) callback(err)
+    else {
+      // check for proxy+ or a greedy root if it exists bail
+      let greedy = i=>/\/{(\w+|proxy\+)}/g.test(i.pathPart)
+      let cancel = result.items.find(greedy)
+      if (cancel) callback('cancel')
+      else callback(null, {arn, restApiId})
+    }
+  })
+}

--- a/src/create/aws/create-http-fallback/write.js
+++ b/src/create/aws/create-http-fallback/write.js
@@ -1,0 +1,55 @@
+let aws = require('aws-sdk')
+
+/**
+ * haha, wow
+ */
+module.exports = function write({app, env}, {restApiId, arn}, callback) {
+  let region = process.env.AWS_REGION
+  let api = new aws.APIGateway({region})
+  api.putRestApi({
+    restApiId,
+    failOnWarnings: true,
+    mode: 'merge',// overwrite
+    body: JSON.stringify({
+      openapi: '3.0.0',
+      info: {
+        version: '2016-09-12T23:19:28Z',
+        title: `${app}-${env}`
+      },
+      paths: {
+        '/{proxy+}': {
+          'x-amazon-apigateway-any-method': {
+            parameters: [{
+              name: 'proxy',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string'
+              }
+            }],
+            'x-amazon-apigateway-integration': {
+              uri: `arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${arn}/invocations`,
+              responses: {
+                default: {
+                  statusCode: '200'
+                }
+              },
+              passthroughBehavior: 'when_no_match',
+              httpMethod: 'POST',
+              cacheNamespace: 'xlr8r',
+              cacheKeyParameters: [
+                'method.request.path.proxy'
+              ],
+              contentHandling: 'CONVERT_TO_TEXT',
+              type: 'aws_proxy'
+            }
+          }
+        }
+      },
+    })
+  },
+  function done(err) {
+    if (err) callback(err)
+    else callback(null, {restApiId, arn})
+  })
+}

--- a/src/create/aws/create-http-lambda-deployments/create.js
+++ b/src/create/aws/create-http-lambda-deployments/create.js
@@ -4,29 +4,29 @@ let print = require('../../_print')
 let getLambda = require('../_get-lambda')
 
 module.exports = function create({app, name, stage}, callback) {
-  setTimeout(function delay() {
-    let lambda = new aws.Lambda({region: process.env.AWS_REGION})
-    lambda.getFunction({
-      FunctionName: stage
-    },
-    function _gotFn(err) {
-      if (err && err.name === 'ResourceNotFoundException') {
+  let lambda = new aws.Lambda({region: process.env.AWS_REGION})
+  lambda.getFunction({
+    FunctionName: stage
+  },
+  function _gotFn(err) {
+    if (err && err.name === 'ResourceNotFoundException') {
+      setTimeout(function delay() {
         print.create('@http', stage)
         createLambda({
           app,
           name,
           stage,
         }, callback)
-      }
-      else if (err) {
-        callback(err)
-      }
-      else {
-        print.skip('@http', stage)
-        callback()
-      }
-    })
-  }, 7000)
+      }, 7000)
+    }
+    else if (err) {
+      callback(err)
+    }
+    else {
+      print.skip('@http', stage)
+      callback()
+    }
+  })
 }
 
 function createLambda({app, name, stage}, callback) {

--- a/src/create/aws/create-http-route/create-route/_response.vtl
+++ b/src/create/aws/create-http-route/create-route/_response.vtl
@@ -28,7 +28,7 @@ $input.path('$.errorMessage')##
 #set($context.responseOverride.header.Set-Cookie = $input.path("$.cookie"))##
 #end##
 ## cors support
-#if($input.path("$.cors"))##
+#if($input.path("$.cors") != "")##
 #set($context.responseOverride.header.Access-Control-Allow-Origin = "*")##
 #end##
 #set($headers = $input.path("$.headers"))## 

--- a/src/create/aws/create-http-routers/index.js
+++ b/src/create/aws/create-http-routers/index.js
@@ -11,7 +11,14 @@ function create(name, callback) {
     let gateway = new aws.APIGateway({region: process.env.AWS_REGION})
     gateway.createRestApi({
       name,
-      minimumCompressionSize: 0
+      minimumCompressionSize: 0,
+      binaryMediaTypes: [
+        'application/octet',
+        'image/*',
+        'audio/*',
+        'video/*',
+        'font/*'
+      ],
     }, callback)
   }, timeout)
 }

--- a/src/create/aws/create-http-static-deployments/create.js
+++ b/src/create/aws/create-http-static-deployments/create.js
@@ -1,0 +1,55 @@
+var waterfall = require('run-waterfall')
+var aws = require('aws-sdk')
+var print = require('../../_print')
+
+module.exports = function create(app, bucket, callback) {
+  let ok = true
+  let region = process.env.AWS_REGION
+  let s3 = new aws.S3({region})
+  print.create('@static', bucket)
+  waterfall([
+    function _createBukkit(callback) {
+      s3.createBucket({
+        Bucket: bucket,
+        ACL: 'public-read'
+      },
+      function _bukkit(err) {
+        if (err && err.code === 'BucketAlreadyOwnedByYou') {
+          ok = false
+          print.skip('@static', bucket)
+        }
+        else if (err && err.code === 'BucketAlreadyExists') {
+          ok = false
+          print.skip('@static', bucket)
+        }
+        else if (err) {
+          ok = false
+          console.log(err)
+        }
+        callback()
+      })
+    },
+    function _putWebsite(callback) {
+      if (ok) {
+        s3.putBucketWebsite({
+          Bucket: bucket,
+          WebsiteConfiguration: {
+            ErrorDocument: {
+              Key: "error.html"
+            },
+            IndexDocument: {
+              Suffix: "index.html"
+            }
+          }
+        },
+        function done(err) {
+          if(err)callback(err)
+          else callback()
+        })
+      }
+      else {
+        callback()
+      }
+    }
+  ], callback)
+}

--- a/src/create/aws/create-http-static-deployments/index.js
+++ b/src/create/aws/create-http-static-deployments/index.js
@@ -1,80 +1,17 @@
-var parallel = require('run-parallel')
-var waterfall = require('run-waterfall')
-var assert = require('@smallwins/validate/assert')
-var aws = require('aws-sdk')
-var print = require('../../_print')
+let assert = require('@smallwins/validate/assert')
+let series = require('run-series')
+let create = require('./create')
 
-module.exports = function _createDeployments(params, callback) {
-
+module.exports = function createS3Buckets(params, callback) {
   assert(params, {
     static: Array
   })
-
-  var staging = _create.bind({}, params.app, params.static[0][1])
-  var production = _create.bind({}, params.app, params.static[1][1])
-
-  parallel([
-    staging,
-    production,
+  series([
+    create.bind({}, params.app, params.static[0][1]),
+    create.bind({}, params.app, params.static[1][1])
   ],
   function _done(err) {
-    if (err) {
-      console.log(err)
-    }
-    callback()
+    if (err) callback(err)
+    else callback()
   })
-}
-
-// TODO: possibly factor into own module for easier testing
-function _create(app, bucket, callback) {
-  let s3 = new aws.S3({region: process.env.AWS_REGION})
-  print.create('@static', bucket)
-  var ok = true
-  waterfall([
-    function _createBukkit(callback) {
-      s3.createBucket({
-        Bucket: bucket,
-        ACL: 'public-read'
-      },
-      function _bukkit(err) {
-        if (err && err.code === 'BucketAlreadyOwnedByYou') {
-          ok = false
-          print.skip('@static', bucket)
-        }
-        else if (err && err.code === 'BucketAlreadyExists') {
-          ok = false
-          print.skip('@static', bucket)
-        }
-        else if (err) {
-          ok = false
-          console.log(err)
-        }
-        callback()
-      })
-    },
-    function _putWebsite(callback) {
-      if (ok) {
-        s3.putBucketWebsite({
-          Bucket: bucket,
-          WebsiteConfiguration: {
-            ErrorDocument: {
-              Key: "error.html"
-            },
-            IndexDocument: {
-              Suffix: "index.html"
-            }
-          }
-        },
-        function _putWWW(err) {
-          if (err) {
-            console.log(err)
-          }
-          callback()
-        })
-      }
-      else {
-        callback()
-      }
-    }
-  ], callback)
 }

--- a/src/create/aws/create-http-static-proxy/index.js
+++ b/src/create/aws/create-http-static-proxy/index.js
@@ -1,0 +1,21 @@
+let assert = require('@smallwins/validate/assert')
+let series = require('run-series')
+let proxy = require('./proxy')
+
+/**
+ * catch any 404 and point it at get-index
+ */
+module.exports = function fallback(params, callback) {
+  assert(params, {
+    app: String,//app name
+    arc: Object,
+  })
+  series([
+    proxy.bind({}, 'staging', params),
+    proxy.bind({}, 'production', params),
+  ],
+  function done(err) {
+    if (err) callback(err)
+    else callback()
+  })
+}

--- a/src/create/aws/create-http-static-proxy/proxy.js
+++ b/src/create/aws/create-http-static-proxy/proxy.js
@@ -1,0 +1,27 @@
+let waterfall = require('run-waterfall')
+let verify = require('./verify')
+let read = require('./read')
+let write = require('./write')
+
+/**
+ * creates `ANY /{proxy+}` for one api pointing to get-index
+ */
+module.exports = function proxy(env, {app, arc}, callback) {
+  waterfall([
+    read.bind({}, {app, env, arc}),
+    verify,
+    write.bind({}, {app, env, arc}),
+  ],
+  function done(err) {
+    if (err && err === 'cancel') {
+      console.log('cancelling')
+      callback()
+    }
+    else if (err) {
+      callback(err)
+    }
+    else {
+      callback()
+    }
+  })
+}

--- a/src/create/aws/create-http-static-proxy/read.js
+++ b/src/create/aws/create-http-static-proxy/read.js
@@ -1,0 +1,51 @@
+let aws = require('aws-sdk')
+let parallel = require('run-parallel')
+
+module.exports = function reads({app, env, arc}, callback) {
+
+  let region = process.env.AWS_REGION
+  let api = new aws.APIGateway({region})
+
+  parallel({
+    // read the restApiId
+    restApiId(callback) {
+      api.getRestApis({
+        limit: 500
+      },
+      function getRestApis(err, apis) {
+        if (err) callback(err)
+        else {
+          let byName = i=> i.name === `${app}-${env}`
+          let api = apis.items.find(byName)
+          callback(null, api.id)
+        }
+      })
+    },
+    // read the s3 bucket arn
+    endpoint(callback) {
+      let isOGS3 = region === 'us-east-1'
+      let domain = isOGS3 ? `https://s3.amazonaws.com/` : `https://s3-${region}.amazonaws.com/`
+      let bucket = getBucket(env, arc.static)
+      callback(null, `${domain}${bucket}`)
+    }
+  }, callback)
+}
+
+
+// helper returns the @static value for the current NODE_ENV
+function getBucket(env, static) {
+  let staging
+  let production
+  static.forEach(thing=> {
+    if (thing[0] === 'staging') {
+      staging = thing[1]
+    }
+    if (thing[0] === 'production') {
+      production = thing[1]
+    }
+  })
+  if (env === 'staging')
+    return staging
+  if (env === 'production')
+    return production
+}

--- a/src/create/aws/create-http-static-proxy/verify.js
+++ b/src/create/aws/create-http-static-proxy/verify.js
@@ -1,0 +1,17 @@
+let aws = require('aws-sdk')
+
+module.exports = function verify({endpoint, restApiId}, callback) {
+  console.log('verify', endpoint)
+  let region = process.env.AWS_REGION
+  let api = new aws.APIGateway({region})
+  api.getResources({restApiId}, function done(err, result) {
+    if (err) callback(err)
+    else {
+      // check for proxy+ or a greedy root if it exists bail
+      let greedy = i=>/\/_static\/{(\w+|proxy\+)}/g.test(i.pathPart)
+      let cancel = result.items.find(greedy)
+      if (cancel) callback('cancel')
+      else callback(null, {endpoint, restApiId})
+    }
+  })
+}

--- a/src/create/aws/create-http-static-proxy/write.js
+++ b/src/create/aws/create-http-static-proxy/write.js
@@ -1,0 +1,58 @@
+let aws = require('aws-sdk')
+
+/**
+ * haha, wow2
+ */
+module.exports = function write({app, env}, {restApiId, endpoint}, callback) {
+  console.log('write', endpoint)
+  let region = process.env.AWS_REGION
+  let api = new aws.APIGateway({region})
+  api.putRestApi({
+    restApiId,
+    failOnWarnings: true,
+    mode: 'merge',
+    body: JSON.stringify({
+      openapi: '3.0.0',
+      info: {
+        version: '2016-09-12T23:19:28Z',
+        title: `${app}-${env}`
+      },
+      paths: {
+        '/_static/{proxy+}': {
+          'x-amazon-apigateway-any-method': {
+            parameters: [{
+              name: 'proxy',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string'
+              }
+            }],
+            'x-amazon-apigateway-integration': {
+              uri: `${endpoint}/{proxy}`,
+              responses: {
+                default: {
+                  statusCode: '200'
+                }
+              },
+              requestParameters: {
+                'integration.request.path.proxy': 'method.request.path.proxy'
+              },
+              passthroughBehavior: 'when_no_match',
+              httpMethod: 'ANY',
+              cacheNamespace: 'xlr8r2',
+              cacheKeyParameters: [
+                'method.request.path.proxy'
+              ],
+              type: 'http_proxy'
+            }
+          }
+        },
+      },
+    })
+  },
+  function done(err) {
+    if (err) callback(err)
+    else callback(null, {restApiId, endpoint})
+  })
+}

--- a/src/create/validate/validators/http.js
+++ b/src/create/validate/validators/http.js
@@ -35,21 +35,32 @@ module.exports = function _http(arc, raw) {
           linenumber: findLineNumber(fkdtuple, raw),
           raw,
           arc,
-          detail: 'Currently .arc only supports get and post for routes. Read more here: https://arc.codes/guides/http',
+          detail: 'Routes must be get, post, put, delete or patch. Read more here: https://arc.codes/guides/http',
         }))
       })
+
+      let missingIndex = !arc[type].some(r=> r[0].toLowerCase() === 'get' && r[1] === '/')
+      if (missingIndex) {
+        errors.push(Err({
+          message: `@http missing "get /"`,
+          linenumber: findHttpLine(raw),
+          raw,
+          arc,
+          detail: '@http must have one get / route. Read more here: https://arc.codes/guides/http',
+        }))
+      }
 
       arc[type].forEach(route=> {
         var path = route[1]
         var err = validPath(path)
         if (err) {
-            errors.push(Err({
-              message: `@${type} invalid route`,
-              linenumber: findLineNumber(route, raw),
-              raw,
-              arc,
-              detail: err.message + ' HTTP reference: https://arc.codes/guides/http',
-            }))
+          errors.push(Err({
+            message: `@${type} invalid route`,
+            linenumber: findLineNumber(route, raw),
+            raw,
+            arc,
+            detail: err.message + ' HTTP reference: https://arc.codes/guides/http',
+          }))
         }
       })
       // for each route in routes
@@ -71,6 +82,16 @@ function findLineNumber(tuple, raw) {
   var lines = raw.split('\n')
   for (var i = 0; i <= lines.length; i++) {
     if (lines[i] && lines[i].startsWith(search)) {
+      return i + 1
+    }
+  }
+  return -1
+}
+
+function findHttpLine(raw) {
+  var lines = raw.split('\n')
+  for (var i = 0; i <= lines.length; i++) {
+    if (lines[i] && lines[i].startsWith('@http')) {
       return i + 1
     }
   }

--- a/src/sandbox/http/fallback.js
+++ b/src/sandbox/http/fallback.js
@@ -1,0 +1,53 @@
+//let fs = require('fs')
+//let url = require('url')
+//let send = require('send')
+//let exists = require('path-exists').sync
+let path = require('path')
+let readArc = require('../../util/read-arc')
+let invoker = require('./invoke-http')
+
+/**
+ * serves static assets found in /public
+ * - if /public/index.html exists it will serve it as /
+ *   (even if `get /` http lambda is defined)
+ */
+module.exports = function _public(req, res, next) {
+  // immediately exit to normal flow if /
+  if (req.path === '/') next()
+  else {
+    // reads all routes
+    let routes = readArc().arc.http
+    // tokenize them [['get', '/']]
+    let tokens = routes.map(r=> [r[0]].concat(r[1].split('/').filter(Boolean)))
+    // tokenize the current req
+    let current = [req.method.toLowerCase()].concat(req.url.split('/').filter(Boolean))
+    // get all exact match routes
+    let exact = tokens.filter(t=> !t.some(v=> v.startsWith(':')))
+    // get all wildcard routes
+    let wild = tokens.filter(t=> t.some(v=> v.startsWith(':')))
+    // look for an exact match
+    let exactMatch = exact.some(t=> t.join('') === current.join(''))
+    // look for a wildcard match
+    let wildMatch = wild.filter(t=> t.length === current.length).some(t=> {
+      // turn :foo tokens into (\S+) regexp
+      let exp = t.map(p=> p.startsWith(':')? '(\\S+)' : p).join('/')
+      let reg = new RegExp(exp)
+      return reg.test(current.join('/'))
+    })
+    // if either exact or wildcard match bail
+    let match = exactMatch || wildMatch
+    if (match) {
+      next()
+    }
+    else {
+      // invoke the get-index lambda function with a proxy payload
+      let exec = invoker({
+        verb: req.method.toLowerCase(),
+        pathToFunction: path.join(process.cwd(), 'src', 'http', `get-index`)
+      })
+      // TODO mock a {proxy+} request payload
+      req.requestContext = {}
+      exec(req, res)
+    }
+  }
+}

--- a/src/sandbox/http/index.js
+++ b/src/sandbox/http/index.js
@@ -9,20 +9,16 @@ let http = require('http')
 // local modules
 let readArc = require('../../util/read-arc')
 let registerHTTP = require('./register-http')
-let registerWebSocket = require('./register-websocket')
-//let public = require('./public-middleware')
+let registerWS = require('./register-websocket')
+let public = require('./public-middleware')
 let fallback = require('./fallback')
 
 // config arcana
-let limit = '6mb';
-let app = Router({mergeparams: true})
-app.use(body.json({limit}))
-app.use(body.urlencoded({
-  extended: false,
-  limit,
-}))
+let app = Router({mergeparams:true})
+app.use(body.json({limit:'6mb'}))
+app.use(body.urlencoded({extended:false, limit:'6mb'}))
+app.use(public)
 app.use(fallback)
-//app.use(public)
 
 // keep a reference up here for fns below
 let server
@@ -46,7 +42,7 @@ app.start = function start(callback) {
 
   // bind ws
   if (web.ws) {
-    websocket = registerWebSocket({app, server})
+    websocket = registerWS({app, server})
   }
 
   // start listening

--- a/src/sandbox/http/index.js
+++ b/src/sandbox/http/index.js
@@ -10,7 +10,8 @@ let http = require('http')
 let readArc = require('../../util/read-arc')
 let registerHTTP = require('./register-http')
 let registerWebSocket = require('./register-websocket')
-let public = require('./public-middleware')
+//let public = require('./public-middleware')
+let fallback = require('./fallback')
 
 // config arcana
 let limit = '6mb';
@@ -20,7 +21,8 @@ app.use(body.urlencoded({
   extended: false,
   limit,
 }))
-app.use(public)
+app.use(fallback)
+//app.use(public)
 
 // keep a reference up here for fns below
 let server

--- a/src/sandbox/http/invoke-http.js
+++ b/src/sandbox/http/invoke-http.js
@@ -1,0 +1,67 @@
+let url = require('url')
+let invoke = require('./invoke-lambda')
+
+/**
+ * builds response middleware for invoke
+ */
+module.exports = function invokeHTTP({verb, pathToFunction}) {
+
+  return function respond(req, res) {
+
+    // HACK api gateway 'Cookie' from express 'cookie'
+    req.headers.Cookie = req.headers.cookie
+    delete req.headers.cookie
+
+    let request = {
+      method: verb,
+      path: url.parse(req.url).pathname,
+      headers: req.headers,
+      query: url.parse(req.url, true).query,
+      body: req.body,
+      params: req.params,
+    }
+
+    // run the lambda sig locally
+    invoke(pathToFunction, request, function _res(err, result) {
+      if (err) res(err)
+      else {
+        res.setHeader('Content-Type', result.type || 'application/json; charset=utf-8')
+        res.statusCode = result.status || result.code || 200
+
+        // remove Secure because localhost won't be SSL (and the cookie won't get set)
+        if (result.cookie)
+          res.setHeader('Set-Cookie', result.cookie.replace('; Secure', '; Path=/'))
+
+        if (result.location)
+          res.setHeader('Location', result.location)
+
+        if (result.cors)
+          res.setHeader('Access-Control-Allow-Origin', '*')
+
+        if (result.headers) {
+          Object.keys(result.headers).forEach(k=> {
+            res.setHeader(k, result.headers[k])
+          })
+        }
+
+        // Re-encode nested JSON responses
+        if (typeof result.json !== 'undefined') {
+          // CYA in case we receive an object instead of encoded JSON
+          try {
+            let body = result.body // noop the try
+            // Real JSON will create an object
+            let maybeRealJSON = JSON.parse(result.body)
+            if (typeof maybeRealJSON !== 'object')
+              result.body = body
+          }
+          catch (e) {
+            // JSON-parsing an object will fail, so JSON stringify it
+            result.body = JSON.stringify(result.body)
+          }
+        }
+
+        res.end(result.body || '\n')
+      }
+    })
+  }
+}

--- a/src/sandbox/http/public-middleware.js
+++ b/src/sandbox/http/public-middleware.js
@@ -6,7 +6,8 @@ let exists = require('path-exists').sync
 
 /**
  * serves static assets found in /public
- * - if /public/index.html exists it will serve it as / (even if `get /` http lambda is defined)
+ * - if /public/index.html exists it will serve it as /
+ *   (even if `get /` http lambda is defined)
  */
 module.exports = function _public(req, res, next) {
 

--- a/src/sandbox/http/register-http.js
+++ b/src/sandbox/http/register-http.js
@@ -1,9 +1,7 @@
-let {join} = require('path')
-let url = require('url')
-
+let join = require('path').join
 let name = require('../../util/get-lambda-name')
 let log = require('./pretty-print-route')
-let invoke = require('./invoke-lambda')
+let invoker = require('./invoke-http')
 
 module.exports = function reg(app, api, type, routes) {
   if (routes) {
@@ -15,64 +13,14 @@ module.exports = function reg(app, api, type, routes) {
       let verb = r[0].toLowerCase()
       let route = r[1]
       let path = name(route)
-      let fun = join(process.cwd(), 'src', type, `${verb}${path}`)
+      let pathToFunction = join(process.cwd(), 'src', type, `${verb}${path}`)
 
       // pretty print the route reg
       log({verb, route, path})
 
       // reg the route with the Router instance
-      app[verb](route, function _http(req, res) {
-
-        // HACK api gateway 'Cookie' from express 'cookie'
-        req.headers.Cookie = req.headers.cookie
-        delete req.headers.cookie
-
-        let request = {
-          method: verb,
-          path: url.parse(req.url).pathname,
-          headers: req.headers,
-          query: url.parse(req.url, true).query,
-          body: req.body,
-          params: req.params,
-        }
-
-        // run the lambda sig locally
-        invoke(fun, request, function _res(err, result) {
-          if (err) res(err)
-          else {
-            res.setHeader('Content-Type', result.type || 'application/json; charset=utf-8')
-            res.statusCode = result.status || result.code || 200
-
-            // remove Secure because localhost won't be SSL (and the cookie won't get set)
-            if (result.cookie)
-              res.setHeader('Set-Cookie', result.cookie.replace('; Secure', '; Path=/'))
-
-            if (result.location)
-              res.setHeader('Location', result.location)
-
-            if (result.cors)
-              res.setHeader('Access-Control-Allow-Origin', '*')
-
-            // Re-encode nested JSON responses
-            if (typeof result.json !== 'undefined') {
-              // CYA in case we receive an object instead of encoded JSON
-              try {
-                let body = result.body // noop the try
-                // Real JSON will create an object
-                let maybeRealJSON = JSON.parse(result.body)
-                if (typeof maybeRealJSON !== 'object')
-                  result.body = body
-              }
-              catch (e) {
-                // JSON-parsing an object will fail, so JSON stringify it
-                result.body = JSON.stringify(result.body)
-              }
-            }
-
-            res.end(result.body || '\n')
-          }
-        })
-      })
+      let exec = invoker({verb, pathToFunction})
+      app[verb](route, exec)
     })
   }
 }

--- a/src/util/run-plugin-promise.js
+++ b/src/util/run-plugin-promise.js
@@ -3,7 +3,7 @@ let path = require('path')
 /* eslint global-require:"off" */
 /**
  * calls a specific plugin function in any plugins registered in .arc
- * 
+ *
  * pluginFunctionName is one of 'beforeDeploy' or 'afterDeploy'
  */
 module.exports = function runPluginFunction(params, pluginFunctionName) {

--- a/test/create/_planner-test.js
+++ b/test/create/_planner-test.js
@@ -137,7 +137,7 @@ test('create planner returns http lambda code plans', t=> {
   var createdeployplans = plans.filter(x => x.action === 'create-http-lambda-deployments')
   t.deepEqual(createdeployplans[0], {action:'create-http-lambda-deployments', app: base.app[0], route:arc.http[0], arc: { http: [ [ 'get', '/' ], [ 'post', '/post' ] ], app: [ 'mah-app' ] }},  'contains create lambda deployment with first of two routes')
   t.deepEqual(createdeployplans[1], {action:'create-http-lambda-deployments', app: base.app[0], route:arc.http[1], arc: { http: [ [ 'get', '/' ], [ 'post', '/post' ] ], app: [ 'mah-app' ] }},  'contains create lambda deployment with second of two routes')
-  t.equal(plans.length, 10, '10 plans exist')
+  t.equal(plans.length, 11, '11 plans exist')
   t.end()
 })
 test('create planner does not return http lambda deployment plans if local', t=> {


### PR DESCRIPTION
WIP. Adds fallback to `get-index` if a route is not found. Combined with architect/functions this enables single page apps to be hosted at the root of the app. 

Example proj has an `.arc` file like this:

```
@app
myapp

@static
staging mystagebukkit
production myprodbukkit

@http
get /
```

The apex handler will proxy requests to s3 buckets defined above:

```javascript
// src/http/get-index/index.js
let arc = require('@architect/functions')
// set spa:true if you always want to load public/index.html
exports.handler = arc.proxy.public({spa:true})
```