### PR TITLE
fixed sandbox/http/index.js to work properly when content-type has ch…

### DIFF
--- a/src/sandbox/http/index.js
+++ b/src/sandbox/http/index.js
@@ -14,12 +14,12 @@ let public = require('./public-middleware')
 let fallback = require('./fallback')
 
 // config arcana
-let jsonTypes = ['application/json', 'application/vnd.api+json']
+let jsonTypes = /^application\/.*json/
 let limit = '6mb';
 let app = Router({mergeparams: true})
 app.use(body.json({
   limit,
-  type: req => jsonTypes.includes(req.headers['content-type'])
+  type:  req => jsonTypes.test(req.headers['content-type'])
 }))
 app.use(body.urlencoded({
   extended: false,


### PR DESCRIPTION
fixed sandbox/http/index.js to work properly when content-type has charset assignment

Thank you for helping out! ✨

Before submitting a pull request, please make sure the you checked the following:

- [x] Forked the repository and created your branch from master
- [x] Make sure the tests pass! `npm it` in the repository root
- [ ] If you've fixed a bug or added code **more** tests are appreciated
- [ ] If you're adding a new command, removing an old command, or changing how a command works, please update the relevant documentation for the command (under the `doc/` folder)
- [ ] Summarize your changes in the [changelog](https://github.com/arc-repos/architect/blob/master/changelog.md)
- [x] If you haven't already please complete the CLA

Learn more about contributing: https://arc.codes/intro/community
