### PR TITLE
Custom AWS layers runtime support

### DIFF
--- a/src/create/aws/create-http-lambda-deployments/create.js
+++ b/src/create/aws/create-http-lambda-deployments/create.js
@@ -3,7 +3,7 @@ let waterfall = require('run-waterfall')
 let print = require('../../_print')
 let getLambda = require('../_get-lambda')
 
-module.exports = function create({app, name, stage}, callback) {
+module.exports = function create({app, name, stage, arc}, callback) {
   let lambda = new aws.Lambda({region: process.env.AWS_REGION})
   lambda.getFunction({
     FunctionName: stage
@@ -16,6 +16,7 @@ module.exports = function create({app, name, stage}, callback) {
           app,
           name,
           stage,
+          arc
         }, callback)
       }, 7000)
     }
@@ -29,7 +30,7 @@ module.exports = function create({app, name, stage}, callback) {
   })
 }
 
-function createLambda({app, name, stage}, callback) {
+function createLambda({app, name, stage, arc}, callback) {
   let lambda = new aws.Lambda({region: process.env.AWS_REGION})
   waterfall([
     function read(callback) {
@@ -37,6 +38,7 @@ function createLambda({app, name, stage}, callback) {
         section: 'http',
         codename: name,
         deployname: stage,
+        arc
       }, callback)
     },
     function write(arn, callback) {

--- a/src/create/aws/create-http-lambda-deployments/index.js
+++ b/src/create/aws/create-http-lambda-deployments/index.js
@@ -8,18 +8,20 @@ module.exports = function createHttpLambdas(params, callback) {
   assert(params, {
     app: String,
     route: Array,
+    arc: Object
   })
 
   let method = params.route[0].toLowerCase()
   let path = getName(params.route[1])
   let app = params.app
+  let arc = params.arc
   let name = `${method}${path}`
   let staging = `${app}-staging-${name}`
   let production = `${app}-production-${name}`
 
   series([
-    create.bind({}, {app, name, stage: staging}),
-    create.bind({}, {app, name, stage: production}),
+    create.bind({}, {app, name, stage: staging, arc}),
+    create.bind({}, {app, name, stage: production, arc}),
   ],
   function _done(err) {
     if (err) callback(err)

--- a/src/create/validate/_regexp.js
+++ b/src/create/validate/_regexp.js
@@ -2,6 +2,8 @@
 module.exports = {
   appname: /^[a-z][a-z|\-|0-9]+/,      // lowercase alphanumeric dasherized (must start with a letter)
   eventname: /^[a-z][a-z|\-|0-9]+/,    // lowercase alphanumeric dasherized (must start with a letter)
+  // aws
+  layer: /arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\d{1}:\d{12}:layer:[a-zA-Z0-9-_]+(:(\$LATEST|[a-zA-Z0-9-_]+))?/,
   // http                              // see: ./_valid-path.js
   // TODO queues
   schedulename: /^[a-z][a-z|\-|0-9]+/, // lowercase alphanumeric dasherized (must start with a letter)

--- a/src/create/validate/index.js
+++ b/src/create/validate/index.js
@@ -1,5 +1,6 @@
 // TODO queues
 var app = require('./validators/app')
+var aws = require('./validators/aws')
 var domain = require('./validators/domain')
 var events = require('./validators/events')
 var http = require('./validators/http')
@@ -35,6 +36,7 @@ function _validate(arc, raw, callback) {
   //
   let validators = [
     app,
+    aws,
     domain,
     events,
     http,

--- a/src/create/validate/validators/aws.js
+++ b/src/create/validate/validators/aws.js
@@ -2,7 +2,7 @@ let regexp = require('../_regexp')
 let Err = require('../_error-factory')
 let getRuntime = require('../../../util/get-runtime')
 let getLayers = require('../../../util/get-layers')
-let validRuntimes = ['nodejs6.10', 'nodejs8.10', 'provided']
+let validRuntimes = getRuntime.validRuntimes
 
 /**
  * aws

--- a/src/create/validate/validators/aws.js
+++ b/src/create/validate/validators/aws.js
@@ -1,0 +1,61 @@
+let regexp = require('../_regexp')
+let Err = require('../_error-factory')
+let getRuntime = require('../../../util/get-runtime')
+let getLayers = require('../../../util/get-layers')
+let validRuntimes = ['nodejs6.10', 'nodejs8.10', 'provided']
+
+/**
+ * aws
+ * ---
+ * validator for @aws
+ *
+ * - assert @aws layer is a valid layer
+ * - assert @aws runtime is a valid runtime
+ */
+module.exports = function app(arc, raw) {
+  var errors = []
+
+  if (!arc.aws) return errors
+
+  // Validate runtime
+  let runtime = getRuntime(arc)
+
+  if (!validRuntimes.includes(runtime)) {
+    errors.push(Err({
+      message: 'runtime is not supported',
+      arc,
+      raw,
+      linenumber: findLineNumber(runtime, raw),
+      detail: 'supported runtimes: ' + validRuntimes.join(', ')
+    }))
+  }
+
+  // Validate layers
+  let layers = getLayers(arc)
+
+  if (Array.isArray(layers)) {
+    layers.forEach(layer => {
+      if (!regexp.layer.test(layer)) {
+        errors.push(Err({
+          message: `layer is not a valid arn`,
+          linenumber: findLineNumber(layer, raw),
+          raw,
+          arc,
+          detail: 'layer should be a valid arn',
+        }))
+      }
+    })
+  }
+
+  return errors
+}
+
+function findLineNumber(search, raw) {
+  var lines = raw.split('\n')
+  for (var i = 0; i <= lines.length; i++) {
+    if (lines[i] && lines[i].includes(search)) {
+      return i + 1
+    }
+  }
+  return -1
+}

--- a/src/util/get-layers.js
+++ b/src/util/get-layers.js
@@ -1,0 +1,26 @@
+
+/**
+ * Extract layers from arc
+ * - finds for `layers` array in json or yaml files
+ * - finds for `layer` tuples in arc file and return a `layers` array
+ */
+module.exports = function getLayers(arc) {
+  if (!arc.aws) return
+
+  // `layers` can come from json or yaml
+  let layers = arc.aws.find(tuple => tuple.includes('layers'))
+  layers = layers && layers[1]
+
+  // `layers` not found, let's check for `layer` tuples in .arc file
+  if (!Array.isArray(layers)) {
+    let layerTuples = arc.aws.filter(tuple => tuple.includes('layer'))
+    if (layerTuples && layerTuples.length > 0) {
+      layers = layerTuples.map(tuple => tuple[1])
+    }
+  }
+
+  // Definitely we didn't found any layer
+  if (!Array.isArray(layers)) return
+
+  return layers
+}

--- a/src/util/get-runtime.js
+++ b/src/util/get-runtime.js
@@ -1,5 +1,7 @@
 
 const DEFAULT_RUNTIME = 'nodejs8.10'
+const validRuntimes = ['nodejs6.10', DEFAULT_RUNTIME, 'provided']
+
 
 /**
  * Extract runtime from @aws section
@@ -12,3 +14,8 @@ module.exports = function getRuntime(arc) {
   let runtime = awsRuntime && awsRuntime[1] || DEFAULT_RUNTIME
   return runtime
 }
+
+/**
+ * Export valid runtimes for validator
+ */
+module.exports.validRuntimes = validRuntimes

--- a/src/util/get-runtime.js
+++ b/src/util/get-runtime.js
@@ -1,0 +1,14 @@
+
+const DEFAULT_RUNTIME = 'nodejs8.10'
+
+/**
+ * Extract runtime from @aws section
+ * - finds `runtime` in @aws section
+ */
+module.exports = function getRuntime(arc) {
+  if (!arc.aws) return DEFAULT_RUNTIME
+
+  let awsRuntime = arc.aws.find(tuple => tuple.includes('runtime'))
+  let runtime = awsRuntime && awsRuntime[1] || DEFAULT_RUNTIME
+  return runtime
+}

--- a/test/create/validate/aws-test.js
+++ b/test/create/validate/aws-test.js
@@ -1,0 +1,92 @@
+var test = require('tape')
+var parse = require('@architect/parser')
+var validate = require('../../../src/create/validate')
+var validRuntimes = require('../../../src/util/get-runtime').validRuntimes
+
+test('aws runtime must be node.js or provided', t=> {
+  t.plan(validRuntimes.length)
+
+  validRuntimes.forEach(runtime=> {
+    var raw = `
+@app
+test-aws
+
+@aws
+runtime ${runtime}
+    `
+    var arc = parse(raw)
+    validate(arc, raw, function _validate(err, result) {
+      if (err) {
+        t.fail('should be a valid runtime')
+        return
+      }
+      t.ok(result, `${runtime} is a valid runtime`)
+    })
+  })
+})
+
+test('aws runtime should fail if not a valid runtime', t=> {
+  t.plan(2)
+  var raw = `
+@app
+test-aws
+
+@aws
+runtime python2
+  `
+
+  var arc = parse(raw)
+  validate(arc, raw, function _validate(err, result) {
+    if (err) {
+      t.ok(true, 'failed')
+      t.ok(/not supported/.test(err[0].message), 'not supported')
+      console.log(err)
+    }
+    else {
+      t.fail('succeeded with an invalid runtime')
+    }
+  })
+})
+
+test('aws runtime should fail if not a valid layer arn', t=> {
+  t.plan(2)
+  var raw = `
+@app
+test-aws
+
+@aws
+layer arn:invalid:layer
+  `
+
+  var arc = parse(raw)
+  validate(arc, raw, function _validate(err, result) {
+    if (err) {
+      t.ok(true, 'failed')
+      t.ok(/not a valid arn/.test(err[0].message), 'not a valid arn')
+      console.log(err)
+    }
+    else {
+      t.fail('succeeded with an invalid runtime')
+    }
+  })
+})
+
+test('aws runtime should ve a valid arn', t=> {
+  t.plan(1)
+  var raw = `
+@app
+test-aws
+
+@aws
+layer arn:aws:lambda:us-east-2:123456789012:layer:my-layer:3
+  `
+
+  var arc = parse(raw)
+  validate(arc, raw, function _validate(err, result) {
+    if (err) {
+      t.fail('should be a valid layer')
+      return
+    }
+    t.ok(result, `${arc.aws[0][1]} is a valid layer`)
+  })
+})


### PR DESCRIPTION
Hello @brianleroux, This is a basic implementation of `runtime` and `layers` support. Let's use this PR to continue our conversation from this morning.

Also check: https://github.com/arc-repos/arc-parser/pull/8 for information around the format

## Example

Use N|Solid Layer as a custom runtime provider:

```
@app
nsolid-arc

@aws
region us-west-2
profile default
runtime provided
layer arn:aws:lambda:us-west-2:800406105498:layer:nsolid-node-10:6

@http
get /
```

## Checklist
- [x] Forked the repository and created your branch from master
- [x] Make sure the tests pass! `npm it` in the repository root
- [x] If you've fixed a bug or added code **more** tests are appreciated
- [x] If you're adding a new command, removing an old command, or changing how a command works, please update the relevant documentation for the command (under the `doc/` folder)
- [ ] Summarize your changes in the [changelog](https://github.com/arc-repos/architect/blob/master/changelog.md)
- [x] If you haven't already please complete the CLA

Learn more about contributing: https://arc.codes/intro/community
