### PR TITLE
Fix query params

### DIFF
--- a/src/sandbox/http/fallback.js
+++ b/src/sandbox/http/fallback.js
@@ -3,6 +3,7 @@
 //let send = require('send')
 //let exists = require('path-exists').sync
 let path = require('path')
+let parseUrl = require('url').parse
 let readArc = require('../../util/read-arc')
 let invoker = require('./invoke-http')
 
@@ -20,7 +21,8 @@ module.exports = function _public(req, res, next) {
     // tokenize them [['get', '/']]
     let tokens = routes.map(r=> [r[0]].concat(r[1].split('/').filter(Boolean)))
     // tokenize the current req
-    let current = [req.method.toLowerCase()].concat(req.url.split('/').filter(Boolean))
+    let {pathname} = parseUrl(req.url)
+    let current = [req.method.toLowerCase()].concat(pathname.split('/').filter(Boolean))
     // get all exact match routes
     let exact = tokens.filter(t=> !t.some(v=> v.startsWith(':')))
     // get all wildcard routes


### PR DESCRIPTION
Hey, this fix prevents `architect` from falsly serving the index page, when there are query params in the url string.