### PR TITLE
fix: get latest set of truncated log streams

### DIFF
--- a/src/logs/logs.js
+++ b/src/logs/logs.js
@@ -11,12 +11,13 @@ module.exports = function logs(name, callback) {
 
     function describeLogStreams(callback) {
       cloud.describeLogStreams({
-        logGroupName: name
+        logGroupName: name,
+        descending: true
       }, callback)
     },
 
     function getLogEvents(result, callback) {
-      var names = result.logStreams.map(l=> l.logStreamName)
+      var names = result.logStreams.map(l=> l.logStreamName).reverse()
       parallel(names.map(logStreamName=> {
         return function getOneLogEventStream(callback) {
           cloud.getLogEvents({


### PR DESCRIPTION
The list of logs returned from this AWS API is truncated once you reach a certain number, not sure if the number is entirely consistent but it started showing up for me and when that happens the architect log command just stops showing recent logs.

This forces the list to be in descending order and then reverses it back before being pulled down and printed to the console.