### PR TITLE
fix: order logs by last event

### DIFF
--- a/src/logs/logs.js
+++ b/src/logs/logs.js
@@ -12,7 +12,8 @@ module.exports = function logs(name, callback) {
     function describeLogStreams(callback) {
       cloud.describeLogStreams({
         logGroupName: name,
-        descending: true
+        descending: true,
+        orderBy: 'LastEventTime' 
       }, callback)
     },
 


### PR DESCRIPTION
Another fix for people who have too many log files. By default the ordering is by name, so if you have less than 50 streams for *today* things were working fine, but once you have more than 50 things they are just being ordered randomly (string sorting on the hash).