### PR TITLE
fix: paginate logs when nuking

### DIFF
--- a/src/logs/nuke.js
+++ b/src/logs/nuke.js
@@ -1,31 +1,30 @@
-let aws = require('aws-sdk')
-let parallel = require('run-parallel')
-let waterfall = require('run-waterfall')
-
-module.exports = function nuke(name, callback) {
-
-  let region = process.env.AWS_REGION
-  let cloud = new aws.CloudWatchLogs({region})
-
-  waterfall([
-    function describeLogStreams(callback) {
-      cloud.describeLogStreams({
-        logGroupName: name
-      }, callback)
-    },
-    function getLogEvents(result, callback) {
-      parallel(result.logStreams.map(logStream=> {
-        return function getOneLogEventStream(callback) {
-          cloud.deleteLogStream({
-            logGroupName: name,
-            logStreamName: logStream.logStreamName,
-          }, callback)
-        }
-      }), callback)
-    },
-  ],
-  function done(err) {
-    if (err) callback(err)
-    else callback()
-  })
+let aws = require('aws-sdk')                                                                                                                          │··········
+let parallel = require('run-parallel')                                                                                                                │··········
+                                                                                                                                                      │··········
+module.exports = function nuke(name, callback) {                                                                                                      │··········
+                                                                                                                                                      │··········
+  let region = process.env.AWS_REGION                                                                                                                 │··········
+  let cloud = new aws.CloudWatchLogs({region})                                                                                                        │··········
+                                                                                                                                                      │··········
+  let deleteLogs = streams => parallel(streams.map(log => cb => {                                                                                     │··········
+    cloud.deleteLogStream({                                                                                                                           │··········
+      logGroupName: name,                                                                                                                             │··········
+      logStreamName: log.logStreamName,                                                                                                               │··········
+    }, cb)                                                                                                                                            │··········
+  }))                                                                                                                                                 │··········
+                                                                                                                                                      │··········
+  let count = 0                                                                                                                                       │··········
+                                                                                                                                                      │··········
+  let run = () => {                                                                                                                                   │··········
+    cloud.describeLogStreams({logGroupName: name}, (err, streams) => {                                                                                │··········
+      streams = streams.logStreams                                                                                                                    │··········
+      if (!streams.length) return callback(null, count)                                                                                               │··········
+      count += streams.length                                                                                                                         │··········
+      deleteLogs(streams, (err) => {                                                                                                                  │··········
+        if (err) return callback(err)                                                                                                                 │··········
+        else run()                                                                                                                                    │··········
+      })                                                                                                                                              │··········
+    })                                                                                                                                                │··········
+  }                                                                                                                                                   │··········
+  run()                                                                                                                                               │··········
 }

--- a/src/logs/nuke.js
+++ b/src/logs/nuke.js
@@ -6,20 +6,21 @@ module.exports = function nuke(name, callback) {
   let region = process.env.AWS_REGION
   let cloud = new aws.CloudWatchLogs({region})
 
-  let deleteLogs = streams => parallel(streams.map(log => cb => {
+  let deleteLogs = (streams, callback) => parallel(streams.map(log => cb => {
     cloud.deleteLogStream({
       logGroupName: name,
       logStreamName: log.logStreamName,
-    }, cb)
-  }))
+    }, cb 
+    )}), callback)
 
   let count = 0
 
   let run = () => {
     cloud.describeLogStreams({logGroupName: name}, (err, streams) => {
-      if (err) return callback(err)
       streams = streams.logStreams
-      if (!streams.length) return callback(null, count)
+      if (!streams.length) {
+        return callback(null, count)
+      }
       count += streams.length
       deleteLogs(streams, (err) => {
         if (err) return callback(err)

--- a/src/logs/nuke.js
+++ b/src/logs/nuke.js
@@ -1,5 +1,4 @@
 let aws = require('aws-sdk')
-let parallel = require('run-parallel')
 
 module.exports = function nuke(name, callback) {
   let region = process.env.AWS_REGION

--- a/src/logs/nuke.js
+++ b/src/logs/nuke.js
@@ -17,6 +17,7 @@ module.exports = function nuke(name, callback) {
 
   let run = () => {
     cloud.describeLogStreams({logGroupName: name}, (err, streams) => {
+      if (err) return callback(err)
       streams = streams.logStreams
       if (!streams.length) return callback(null, count)
       count += streams.length

--- a/src/logs/nuke.js
+++ b/src/logs/nuke.js
@@ -1,30 +1,30 @@
-let aws = require('aws-sdk')                                                                                                                          │··········
-let parallel = require('run-parallel')                                                                                                                │··········
-                                                                                                                                                      │··········
-module.exports = function nuke(name, callback) {                                                                                                      │··········
-                                                                                                                                                      │··········
-  let region = process.env.AWS_REGION                                                                                                                 │··········
-  let cloud = new aws.CloudWatchLogs({region})                                                                                                        │··········
-                                                                                                                                                      │··········
-  let deleteLogs = streams => parallel(streams.map(log => cb => {                                                                                     │··········
-    cloud.deleteLogStream({                                                                                                                           │··········
-      logGroupName: name,                                                                                                                             │··········
-      logStreamName: log.logStreamName,                                                                                                               │··········
-    }, cb)                                                                                                                                            │··········
-  }))                                                                                                                                                 │··········
-                                                                                                                                                      │··········
-  let count = 0                                                                                                                                       │··········
-                                                                                                                                                      │··········
-  let run = () => {                                                                                                                                   │··········
-    cloud.describeLogStreams({logGroupName: name}, (err, streams) => {                                                                                │··········
-      streams = streams.logStreams                                                                                                                    │··········
-      if (!streams.length) return callback(null, count)                                                                                               │··········
-      count += streams.length                                                                                                                         │··········
-      deleteLogs(streams, (err) => {                                                                                                                  │··········
-        if (err) return callback(err)                                                                                                                 │··········
-        else run()                                                                                                                                    │··········
-      })                                                                                                                                              │··········
-    })                                                                                                                                                │··········
-  }                                                                                                                                                   │··········
-  run()                                                                                                                                               │··········
+let aws = require('aws-sdk')
+let parallel = require('run-parallel')
+
+module.exports = function nuke(name, callback) {
+
+  let region = process.env.AWS_REGION
+  let cloud = new aws.CloudWatchLogs({region})
+
+  let deleteLogs = streams => parallel(streams.map(log => cb => {
+    cloud.deleteLogStream({
+      logGroupName: name,
+      logStreamName: log.logStreamName,
+    }, cb)
+  }))
+
+  let count = 0
+
+  let run = () => {
+    cloud.describeLogStreams({logGroupName: name}, (err, streams) => {
+      streams = streams.logStreams
+      if (!streams.length) return callback(null, count)
+      count += streams.length
+      deleteLogs(streams, (err) => {
+        if (err) return callback(err)
+        else run()
+      })
+    })
+  }
+  run()
 }

--- a/src/logs/nuke.js
+++ b/src/logs/nuke.js
@@ -2,31 +2,8 @@ let aws = require('aws-sdk')
 let parallel = require('run-parallel')
 
 module.exports = function nuke(name, callback) {
-
   let region = process.env.AWS_REGION
   let cloud = new aws.CloudWatchLogs({region})
 
-  let deleteLogs = (streams, callback) => parallel(streams.map(log => cb => {
-    cloud.deleteLogStream({
-      logGroupName: name,
-      logStreamName: log.logStreamName,
-    }, cb 
-    )}), callback)
-
-  let count = 0
-
-  let run = () => {
-    cloud.describeLogStreams({logGroupName: name}, (err, streams) => {
-      streams = streams.logStreams
-      if (!streams.length) {
-        return callback(null, count)
-      }
-      count += streams.length
-      deleteLogs(streams, (err) => {
-        if (err) return callback(err)
-        else run()
-      })
-    })
-  }
-  run()
+  cloud.deleteLogGroup({logGroupName: name}, callback)
 }


### PR DESCRIPTION
There’s no easy way to tell that you’re being paginated. You can check if the length of the streams is 50 but that would be error prone for cases where there legitimately is only 50 logs. Instead, I just paginate through log streams deleting them until they are all gone. 

fixes #311