### PR TITLE
fix: audit breaks on @ws functions

### DIFF
--- a/src/audit/_reads.js
+++ b/src/audit/_reads.js
@@ -70,4 +70,5 @@ function findtype(report, functionname) {
   if (report.types.tables.includes(functionname)) return 'tables'
   if (report.types.text.includes(functionname)) return 'text'
   if (report.types.xml.includes(functionname)) return 'xml'
+  if (report.types.ws.includes(functionname)) return 'ws'
 }


### PR DESCRIPTION
This fix is a quick hack, a better fix would be to just make this work dynamically, all the return strings match the keys on the report object so it’s not too hard, I just didn’t have the time to test it :)