### PR TITLE
Enable CORS for sandbox

### DIFF
--- a/src/sandbox/http/index.js
+++ b/src/sandbox/http/index.js
@@ -46,6 +46,15 @@ app.start = function start(callback) {
 
   // create an actual server; how quaint!
   server = http.createServer(function _request(req, res) {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Request-Method', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET');
+    res.setHeader('Access-Control-Allow-Headers', '*');
+    if (req.method === 'OPTIONS') {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
     app(req, res, finalhandler(req, res))
   })
 


### PR DESCRIPTION
Suggestion here is to enable CORS for the sandbox. Seeing that it is a local dev environment seems safe to assume devs just want to test everything.

Staging seems to be the place to deal with testing CORS permissions.